### PR TITLE
Fix uninstall instructions

### DIFF
--- a/justfile
+++ b/justfile
@@ -85,6 +85,8 @@ flatpak:
 # Uninstalls installed files
 uninstall:
     rm {{bin-dst}}
+    rm {{desktop-dst}}
+    rm {{metainfo-dst}}
 
 # Vendor dependencies locally
 vendor:

--- a/justfile
+++ b/justfile
@@ -87,6 +87,9 @@ uninstall:
     rm {{bin-dst}}
     rm {{desktop-dst}}
     rm {{metainfo-dst}}
+    for size in `ls {{icons-src}}`; do \
+        rm "{{icons-dst}}/$size/apps/{{APPID}}.svg"; \
+    done
 
 # Vendor dependencies locally
 vendor:


### PR DESCRIPTION
As it works now `just uninstall` doesn't remove the .desktop file or any others besides the binary, which seems like unintended behavior.